### PR TITLE
[auto] update to Go 1.23.6 and enable custom lint rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/conductorone/baton-sdk v0.7.16
 	github.com/ennyjfrick/ruleguard-logfatal v0.0.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
-	github.com/quasilyte/go-ruleguard/dsl v0.3.22
+	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	go.uber.org/zap v1.27.1
 	golang.org/x/text v0.31.0
 	google.golang.org/protobuf v1.36.10

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/pquerna/xjwt/xkeyset v0.0.0-20241217022915-10fc997b2a9f/go.mod h1:zLK
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/quasilyte/go-ruleguard v0.4.4 h1:53DncefIeLX3qEpjzlS1lyUmQoUEeOWPFWqaTJq9eAQ=
 github.com/quasilyte/go-ruleguard v0.4.4/go.mod h1:Vl05zJ538vcEEwu16V/Hdu7IYZWyKSwIy4c88Ro1kRE=
-github.com/quasilyte/go-ruleguard/dsl v0.3.22 h1:wd8zkOhSNr+I+8Qeciml08ivDt1pSXe60+5DqOpCjPE=
-github.com/quasilyte/go-ruleguard/dsl v0.3.22/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23 h1:lxjt5B6ZCiBeeNO8/oQsegE6fLeCzuMRoVWSkXC4uvY=
+github.com/quasilyte/go-ruleguard/dsl v0.3.23/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/gogrep v0.5.0 h1:eTKODPXbI8ffJMN+W2aE0+oL0z/nh8/5eNdiO34SOAo=
 github.com/quasilyte/gogrep v0.5.0/go.mod h1:Cm9lpz9NZjEoL1tgZ2OgeUKPIxL1meE7eo60Z6Sk+Ng=
 github.com/quasilyte/stdinfo v0.0.0-20220114132959-f7386bf02567 h1:M8mH9eK4OUR4lu7Gd+PU1fV2/qnDNfzT635KRSObncs=

--- a/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
+++ b/vendor/github.com/quasilyte/go-ruleguard/dsl/dsl.go
@@ -16,6 +16,10 @@ type Matcher map[string]Var
 //	  `a/b/foo.Bar` type during the pattern execution.
 func (m Matcher) Import(pkgPath string) {}
 
+// ImportAs is like Import, but can handle "/v2" packages
+// and package name conflicts (e.g. "x/path" vs "y/path").
+func (m Matcher) ImportAs(pkgPath, localName string) {}
+
 // Match specifies a set of patterns that match a rule being defined.
 // Pattern matching succeeds if at least 1 pattern matches.
 //
@@ -106,7 +110,7 @@ type Var struct {
 	Const bool
 
 	// ConstSlice reports whether expr matched by var is a slice literal
-	// consisting of contant elements.
+	// consisting of constant elements.
 	//
 	// We need a separate Const-like predicate here because Go doesn't
 	// treat slices of const elements as constants, so including

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -385,7 +385,7 @@ github.com/pquerna/xjwt
 # github.com/pquerna/xjwt/xkeyset v0.0.0-20241217022915-10fc997b2a9f
 ## explicit; go 1.23
 github.com/pquerna/xjwt/xkeyset
-# github.com/quasilyte/go-ruleguard/dsl v0.3.22
+# github.com/quasilyte/go-ruleguard/dsl v0.3.23
 ## explicit; go 1.15
 github.com/quasilyte/go-ruleguard/dsl
 github.com/quasilyte/go-ruleguard/dsl/types


### PR DESCRIPTION
- update Go version to 1.23.6
- enable rulecheck-logfatal custom lint rules
