### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-victorops/main.go
+++ b/cmd/baton-victorops/main.go
@@ -47,7 +47,7 @@ func getConnector(ctx context.Context, vc *cfg.Victorops) (types.ConnectorServer
 		return nil, err
 	}
 
-	cb, err := connector.New(ctx, vc.VictoropsApiId, vc.VictoropsApiKey)
+	cb, err := connector.New(ctx, vc.VictoropsApiId, vc.VictoropsApiKey, vc.BaseUrl)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))
 		return nil, err

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -6,6 +6,7 @@ import "reflect"
 type Victorops struct {
 	VictoropsApiId string `mapstructure:"victorops-api-id"`
 	VictoropsApiKey string `mapstructure:"victorops-api-key"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Victorops) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,6 +11,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the VictorOps API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the VictorOps API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,13 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/field"
 )
 
+var (
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the VictorOps API URL (for testing)"),
+	)
+)
+
 var Config = field.NewConfiguration([]field.SchemaField{
 	field.StringField(
 		"victorops-api-id",
@@ -17,6 +24,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		field.WithRequired(true),
 		field.WithDescription("The API key for the VictorOps API"),
 	),
+	BaseURLField,
 })
 
 func ValidateConfig(c *Victorops) error {

--- a/pkg/connector/client/client.go
+++ b/pkg/connector/client/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	BaseUrl = "https://api.victorops.com"
+	DefaultBaseURL = "https://api.victorops.com"
 
 	UsersEndpoint = "/api-public/v1/user"
 
@@ -30,13 +30,17 @@ type VictorOpsClient struct {
 	baseUrl    *url.URL
 }
 
-func NewVictorOpsClient(ctx context.Context, clientId, apiKey string) (*VictorOpsClient, error) {
+func NewVictorOpsClient(ctx context.Context, clientId, apiKey, baseURL string) (*VictorOpsClient, error) {
 	httpClient, err := uhttp.NewClient(ctx, uhttp.WithLogger(true, ctxzap.Extract(ctx)))
 	if err != nil {
 		return nil, err
 	}
 
-	baseUrl, err := url.Parse(BaseUrl)
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+
+	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +49,7 @@ func NewVictorOpsClient(ctx context.Context, clientId, apiKey string) (*VictorOp
 		httpClient: uhttp.NewBaseHttpClient(httpClient),
 		clientId:   clientId,
 		apiKey:     apiKey,
-		baseUrl:    baseUrl,
+		baseUrl:    parsedURL,
 	}, nil
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -45,8 +45,8 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, clientId, apiKey string) (*Connector, error) {
-	opsClient, err := client.NewVictorOpsClient(ctx, clientId, apiKey)
+func New(ctx context.Context, clientId, apiKey, baseURL string) (*Connector, error) {
+	opsClient, err := client.NewVictorOpsClient(ctx, clientId, apiKey, baseURL)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-victorops/main.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/client/client.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-victorops --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.