### PR TITLE
Update connector page title to include parent company name

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,6 +1,6 @@
 ---
-title: Set up a VictorOps connector
-og:title: Set up a VictorOps connector - C1 docs
+title: "Set up a Splunk VictorOps connector"
+og:title: "Set up a Splunk VictorOps connector"
 og:description: Integrate your Splunk VictorOps instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
 description: C1 provides identity governance and just-in-time provisioning for Splunk VictorOps. Integrate your VictorOps instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
 sidebarTitle: "Splunk VictorOps"
@@ -45,7 +45,7 @@ Generate a new API key.
 Carefully copy and save the newly generated **API key**. 
 </Step>
 </Steps>
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the VictorOps connector
 
@@ -102,7 +102,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your VictorOps connector is now pulling access data into C1.
+**Done.** Your VictorOps connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -222,7 +222,7 @@ Create a namespace in which to run C1 connectors (if desired), then apply the se
 Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the VictorOps connector to. VictorOps data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
-**That's it!** Your VictorOps connector is now pulling access data into C1.
+**Done.** Your VictorOps connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>


### PR DESCRIPTION
This PR updates the connector page title and og:title to include the parent company name for better discoverability and consistency across connector docs.

Also replaces any remaining instances of `That's it!` with `Done.`