### PR TITLE
fix: mark victorops-api-key as isSecret in config_schema

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,6 +25,7 @@ var Config = field.NewConfiguration([]field.SchemaField{
 		"victorops-api-key",
 		field.WithRequired(true),
 		field.WithDescription("The API key for the VictorOps API"),
+		field.WithIsSecret(true),
 	),
 	BaseURLField,
 })


### PR DESCRIPTION
## Summary
Marks the credential field(s) **victorops-api-key** as `isSecret: true` so the value is treated as a secret — masked in the UI and logs and stored securely rather than in plaintext.

Found by the connector config secret-ness audit (phase 16).

`config_schema.json` is generated at build time from `pkg/config/config.go` and is not committed to this repo, so `field.WithIsSecret(true)` is the authoritative fix. `victorops-api-id` is an identifier and left non-secret.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)