### PR TITLE
docs: fix frontmatter title formatting

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Set up a Splunk VictorOps connector"
-og:title: "Set up a Splunk VictorOps connector"
+title: Set up a Splunk VictorOps connector
+og:title: Set up a Splunk VictorOps connector - C1 docs
 og:description: Integrate your Splunk VictorOps instance with C1 to run user access reviews, enable just-in-time access requests, and easily provision and deprovision access.
 description: C1 provides identity governance and just-in-time provisioning for Splunk VictorOps. Integrate your VictorOps instance with C1 to run user access reviews (UARs) and enable just-in-time access requests.
 sidebarTitle: "Splunk VictorOps"


### PR DESCRIPTION
Removes unnecessary quotes from title frontmatter and adds the standard " - C1 docs" suffix to og:title, matching the published docs site format.